### PR TITLE
Settings: Set ADB notification on by default

### DIFF
--- a/res/xml/development_prefs.xml
+++ b/res/xml/development_prefs.xml
@@ -143,7 +143,8 @@
             android:key="adb_notify"
             android:title="@string/adb_notify"
             android:summary="@string/adb_notify_summary"
-            android:dependency="enable_adb" />
+            android:dependency="enable_adb"
+            android:defaultValue="true" />
 
         <SwitchPreference
             android:key="adb_over_network"


### PR DESCRIPTION
Fixes the wrong initial state shown in settings.

Change-Id: Icd08c21a3327c05103c7738c19cbf1c20306fa3a